### PR TITLE
feat: Add 'export type' for .d.ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "barreler",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Generator for barrel files (export from index files) for JavaScript and TypeScript.",
   "bin": {
     "barreler": "./lib/cli/index.js"

--- a/src/barreler/exporter/exporter.ts
+++ b/src/barreler/exporter/exporter.ts
@@ -4,7 +4,7 @@ import {
   appendFile,
   compareFileExportsFirst,
   compareAlphabetically,
-  compareDefaultFirst
+  compareDefaultFirst,
 } from "../util";
 
 export class Exporter {
@@ -42,7 +42,8 @@ export class Exporter {
   }
 
   private async exportStringLineToFile(line: ExportLine, file: string) {
-    const toBeWritten = `export ${line.whatToExport} from '.${line.fromFile}';\n`;
+    const typePart = line.fromFile.includes(".d") ? "type " : "";
+    const toBeWritten = `export ${typePart}${line.whatToExport} from '.${line.fromFile}';\n`;
 
     await removeExportLinesBeforeUpdating(file, line.fromFile);
     await appendFile(file, toBeWritten);
@@ -57,14 +58,14 @@ export class Exporter {
     listOfExports = listOfExports.sort(compareDefaultFirst);
 
     const listOfExportables = listOfExports
-      .map(exp => {
+      .map((exp) => {
         if (!exp.isDefault) return exp.name;
 
         return `default as ${exp.name}`;
       })
       .join(", ");
-
-    const toBeWritten = `export { ${listOfExportables} } from '.${line.fromFile}';\n`;
+    const typePart = line.fromFile.includes(".d") ? "type " : "";
+    const toBeWritten = `export ${typePart}{ ${listOfExportables} } from '.${line.fromFile}';\n`;
 
     await removeExportLinesBeforeUpdating(file, line.fromFile);
     await appendFile(file, toBeWritten);


### PR DESCRIPTION
Add the 'type' word when the barrel is created using a file with '.d.ts' sufix, for example for this React componente:

```
- src/components/Title
    - Title.tsx
    - Title.d.ts
```

barrel created before this PR:

**index.ts**

```
export { Title } from './Title';
export { TitleProps } from './Title.d';
```

with the next error:

`Re-exporting a type when 'isolatedModules' is enabled requires using 'export type'.ts(1205)`

**barrel after this PR:**

**index.ts**

```
export { Title } from './Title';
export type { TitleProps } from './Title.d';
```